### PR TITLE
Fix ActiveTrackerTest. Wrong scheduler was being used.

### DIFF
--- a/uleak/src/test/java/com/uber/uleak/ActiveTrackerTest.java
+++ b/uleak/src/test/java/com/uber/uleak/ActiveTrackerTest.java
@@ -90,7 +90,7 @@ public class ActiveTrackerTest {
     RxJavaPlugins.setIoSchedulerHandler(new Function<Scheduler, Scheduler>() {
       @Override
       public Scheduler apply(Scheduler scheduler) throws Exception {
-        return scheduler;
+        return ActiveTrackerTest.this.scheduler;
       }
     });
     errorRelay = PublishSubject.create();


### PR DESCRIPTION
This pull request is a simple fix for ActiveTrackerTest which uses the correct scheduler so tests pass.
